### PR TITLE
fix(config): change order module when nuxt/axios is added

### DIFF
--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -108,13 +108,13 @@ module.exports = {
     // Doc: https://buefy.github.io/#/documentation
     'nuxt-buefy',
     <%_ } _%>
-    <%_ if (axios) { _%>
-    // Doc: https://axios.nuxtjs.org/usage
-    '@nuxtjs/axios',
-    <%_ } _%>
     <%_ if (typo) { _%>
     // Doc: https://github.com/TYPO3-Initiatives/nuxt-typo3
     'nuxt-typo3',
+    <%_ } _%>
+    <%_ if (axios) { _%>
+    // Doc: https://axios.nuxtjs.org/usage
+    '@nuxtjs/axios',
     <%_ } _%>
     <%_ if (pwa) { _%>
     '@nuxtjs/pwa'


### PR DESCRIPTION
since nuxt-typo3 depends on nuxt/axios module and when axios is added separately then we should load them in specific order. 